### PR TITLE
2fst: handle timescale

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -16,6 +16,7 @@ pub enum FstFileType {
 pub struct FstInfo {
     pub start_time: u64,
     // TODO: better abstraction
+    /// All times in the file are stored in units of 10^timescale_exponent s.
     pub timescale_exponent: i8,
     pub version: String,
     pub date: String,


### PR DESCRIPTION
GTKWave's `vcd2fst` ignore the VCD timescale factor. The only detail is that `2fst` is ~16x slower, but that is workable.