### PR TITLE
Add Differential Fuzzing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 # released under BSD 3-Clause License
 # author: Kevin Laeufer <laeufer@cornell.edu>
 
+[workspace]
+
+members = ["fuzz"]
+
 [package]
 name = "fst-writer"
 version = "0.2.6"

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "fst-writer-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+fstapi = "0.0.2"
+libfuzzer-sys = "0.4"
+tempfile = "3.14.0"
+wellen = "0.13.6"
+
+[dependencies.fst-writer]
+path = ".."
+
+[[bin]]
+name = "fstapi_diff"
+path = "fuzz_targets/fstapi_diff.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,9 @@
+Crate for fuzzing `fst-writer` using [`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz/).
+
+## Usage
+
+See [`cargo-fuzz` Usage](https://github.com/rust-fuzz/cargo-fuzz?tab=readme-ov-file#usage) for details, but in short run the following command in this directory:
+
+```sh
+cargo +nightly fuzz run fstapi_diff
+```

--- a/fuzz/fuzz_targets/fstapi_diff.rs
+++ b/fuzz/fuzz_targets/fstapi_diff.rs
@@ -1,0 +1,119 @@
+#![no_main]
+
+use fst_writer::{open_fst, FstFileType, FstInfo, FstSignalType, FstVarDirection, FstVarType};
+use fstapi::{var_dir, var_type, Writer};
+use libfuzzer_sys::fuzz_target;
+use tempfile::tempdir;
+use wellen::GetItem;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 8 {
+        return;
+    }
+
+    let outdir = tempdir().unwrap();
+
+    // Create the waveform.
+    let fstfile = outdir.path().join("fstapi.fst");
+    let mut fstapi = Writer::create(&fstfile, true)
+        .unwrap()
+        .comment("FST waveform example")
+        .unwrap()
+        .timescale_from_str("1ns")
+        .unwrap();
+
+    let info = FstInfo {
+        start_time: 0,
+        timescale_exponent: -9,
+        version: "0.0.0".to_string(),
+        date: "2034-10-10".to_string(),
+        file_type: FstFileType::Verilog,
+    };
+    let writerfile = outdir.path().join("fst-writer.fst");
+    let mut writer = open_fst(&writerfile, &info).unwrap();
+
+    let vars = (0..(data[0] as usize).min(1))
+        .map(|i| {
+            let name = &format!("s{}", i);
+            let width = 8;
+            (
+                fstapi
+                    .create_var(var_type::VCD_REG, var_dir::OUTPUT, width, name, None)
+                    .unwrap(),
+                writer
+                    .var(
+                        name,
+                        FstSignalType::bit_vec(8),
+                        FstVarType::Logic,
+                        FstVarDirection::Output,
+                        None,
+                    )
+                    .unwrap(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    if vars.is_empty() {
+        return;
+    }
+
+    let mut writer = writer.finish().unwrap();
+
+    let mut timestamp: u64 = 0;
+
+    fstapi.emit_time_change(0).unwrap();
+    writer.time_change(0).unwrap();
+
+    for chunk in data[1..].chunks(3) {
+        let &[dt, signal, value] = chunk else {
+            break;
+        };
+
+        timestamp += dt.min(1) as u64;
+        let signal = vars[signal as usize % vars.len()];
+        let value = format!("{:08b}", value);
+
+        println!("{} {} {}", timestamp, signal.0, value);
+
+        fstapi.emit_time_change(timestamp).unwrap();
+        fstapi
+            .emit_value_change(signal.0, value.as_bytes())
+            .unwrap();
+
+        writer.time_change(timestamp).unwrap();
+        writer.signal_change(signal.1, value.as_bytes()).unwrap();
+    }
+
+    writer.finish().unwrap();
+
+    drop(fstapi);
+
+    println!("Files: {:?} {:?}", fstfile, writerfile);
+
+    // read
+    let fstwave = wellen::simple::read(fstfile).unwrap();
+    let writerwave = wellen::simple::read(writerfile).unwrap();
+
+    // Some times the timetable differ in how the times are being duplicated.
+    fn dedup<T: Clone + PartialEq>(x: &[T]) -> Vec<T> {
+        let mut x = x.to_vec();
+        x.dedup();
+        x
+    }
+
+    assert_eq!(dedup(fstwave.time_table()), dedup(writerwave.time_table()));
+    let vars = |wave: &wellen::simple::Waveform| {
+        let h = wave.hierarchy();
+        h.vars()
+            .map(|r| h.get(r))
+            .map(|v| v.full_name(h))
+            .collect::<Vec<_>>()
+    };
+
+    for (fstvar, writervar) in vars(&fstwave)
+        .into_iter()
+        .zip(vars(&writerwave).into_iter())
+    {
+        assert_eq!(fstvar, writervar);
+    }
+});

--- a/tests/write_read.rs
+++ b/tests/write_read.rs
@@ -9,6 +9,42 @@ use fst_writer::*;
 use wellen::{GetItem, SignalRef, Time};
 
 #[test]
+fn write_read_empty() {
+    let filename = "tests/empty.fst";
+    let version = "test 0.2.3";
+    let date = "2034-10-10";
+
+    ///////// write
+    let info = FstInfo {
+        start_time: 0,
+        timescale_exponent: 0,
+        version: version.to_string(),
+        date: date.to_string(),
+        file_type: FstFileType::Verilog,
+    };
+    let mut writer = open_fst(filename, &info).unwrap();
+
+    let _var = writer
+        .var(
+            "a",
+            FstSignalType::bit_vec(1),
+            FstVarType::Logic,
+            FstVarDirection::Implicit,
+            None,
+        )
+        .unwrap();
+
+    let writer = writer.finish().unwrap();
+
+    // writer.time_change(0).unwrap();
+    // writer.signal_change(var, b"0").unwrap();
+
+    writer.finish().unwrap();
+
+    drop(wellen::simple::read(filename).unwrap());
+}
+
+#[test]
 fn write_read_simple() {
     let filename = "tests/simple.fst";
     let version = "test 0.2.3";


### PR DESCRIPTION
Added to see if I could find a smaller reproduction for https://github.com/ekiwi/fst-writer/issues/2#issuecomment-2555953325, but the fuzzer is still failing very early for that.

The fuzzer writes a bunch random signals with random timestamps, using both `fstapi` and `fst-writter`, read them back, and check if the results are equal.

Currently it panics after a couple runs on "I/O Operation failed" when trying to read back the fst file written by `fst-writer`. One such case is when writing a FST file with no signals, which I added a test for, but it still fails for some other small test cases with more than zero signals.